### PR TITLE
Add bootstrap.sh, and selectable AXL transfer types 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ langauge: c
 dist: trusty
 
 compiler:
-  - gcc
-  - clang
 
 matrix:
   include:

--- a/README.md
+++ b/README.md
@@ -15,42 +15,13 @@ For usage, see [src/filo.h](src/filo.h), [test/test\_filo.c](test/test_filo.c), 
 
 To build dependencies:
 
-    git clone git@github.com:ECP-VeloC/KVTree.git  KVTree.git
-    git clone git@github.com:ECP-VeloC/AXL.git     AXL.git
-    git clone git@github.com:ECP-VeloC/spath.git   spath.git
-
-    mkdir install
-
-    mkdir build
-    cd build
-    cmake -DCMAKE_INSTALL_PREFIX=../install -DMPI=ON ../KVTree.git
-    make clean
-    make
-    make install
-    make test
-    cd ..
-
-    rm -rf build
-    mkdir build
-    cd build
-    cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../install ../AXL.git
-    make clean
-    make
-    make install
-    cd ..
-
-    rm -rf build
-    mkdir build
-    cd build
-    cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../install ../spath.git
-    make clean
-    make
-    make install
-    cd ..
+    ./bootstrap.sh
 
 To build filo:
 
-    cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=./install -DWITH_KVTREE_PREFIX=`pwd`/install -DWITH_AXL_PREFIX=`pwd`/install -DWITH_SPATH_PREFIX=`pwd`/install .
+    mkdir build
+    cd build
+    cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../install ..
     make
     make install
 
@@ -63,7 +34,7 @@ All the tests can be run with:
 
 To build a test for the filo API:
 
-    mpicc -g -O0 -o test_filo test_filo.c -I../install/include -L../install/lib64 -I../src -L../src -lkvtree -laxl -lspath -lfilo
+    mpicc -g -O0 -o test_filo ../test/test_filo.c -I../install/include -L../install/lib64 -I../src -L../src -lkvtree -laxl -lspath -lfilo
 
 ## Release
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+#
+# This is an easy-bake script to download and build all FILO's external
+# dependencies.  The dependencies will be built in filo/deps/ and
+# installed to filo/install/
+#
+# Usage:
+#
+#   ./bootstrap.sh
+
+ROOT="$(pwd)"
+
+mkdir -p deps
+mkdir -p install
+INSTALL_DIR=$ROOT/install
+
+cd deps
+
+repos=(https://github.com/ECP-Veloc/KVTree.git
+    https://github.com/ECP-Veloc/AXL.git
+    https://github.com/ECP-Veloc/spath.git
+)
+
+for i in "${repos[@]}" ; do
+	# Get just the name of the project (like "mercury")
+	name=$(basename $i | sed 's/\.git//g')
+	if [ -d $name ] ; then
+		echo "$name already exists, skipping it"
+	else
+		git clone $i
+	fi
+done
+
+cd KVTree
+mkdir -p build && cd build
+cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DMPI=ON ..
+make -j `nproc`
+make install
+cd ../..
+
+cd AXL
+mkdir -p build && cd build
+cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DAXL_ASYNC_DAEMON=OFF -DMPI=ON ..
+make -j `nproc`
+make install
+cd ../..
+
+# spath
+cd spath
+mkdir -p build && cd build
+cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DMPI=ON ..
+make -j `nproc`
+make install
+#make test
+
+cd "$ROOT"
+
+echo "*************************************************************************"
+echo "Dependencies are all built.  You can now build FILO with:"
+echo ""
+echo "    mkdir -p build && cd build"
+echo "    cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR ../"
+echo "    make"
+echo ""
+echo "*************************************************************************"

--- a/cmake/FindAXL.cmake
+++ b/cmake/FindAXL.cmake
@@ -10,12 +10,12 @@ FIND_PATH(WITH_AXL_PREFIX
 
 FIND_LIBRARY(AXL_LIBRARIES
     NAMES axl
-    HINTS ${WITH_AXL_PREFIX}/lib
+    HINTS ${WITH_AXL_PREFIX}/lib install/lib64
 )
 
 FIND_PATH(AXL_INCLUDE_DIRS
     NAMES axl.h
-    HINTS ${WITH_AXL_PREFIX}/include
+    HINTS ${WITH_AXL_PREFIX}/include install/include
 )
 
 INCLUDE(FindPackageHandleStandardArgs)

--- a/cmake/FindKVTREE.cmake
+++ b/cmake/FindKVTREE.cmake
@@ -10,12 +10,12 @@ FIND_PATH(WITH_KVTREE_PREFIX
 
 FIND_LIBRARY(KVTREE_LIBRARIES
     NAMES kvtree
-    HINTS ${WITH_KVTREE_PREFIX}/lib
+    HINTS ${WITH_KVTREE_PREFIX}/lib install/lib64
 )
 
 FIND_PATH(KVTREE_INCLUDE_DIRS
     NAMES kvtree.h
-    HINTS ${WITH_KVTREE_PREFIX}/include
+    HINTS ${WITH_KVTREE_PREFIX}/include install/include
 )
 
 INCLUDE(FindPackageHandleStandardArgs)

--- a/cmake/FindSPATH.cmake
+++ b/cmake/FindSPATH.cmake
@@ -10,12 +10,12 @@ FIND_PATH(WITH_SPATH_PREFIX
 
 FIND_LIBRARY(SPATH_LIBRARIES
     NAMES spath
-    HINTS ${WITH_SPATH_PREFIX}/lib
+    HINTS ${WITH_SPATH_PREFIX}/lib install/lib64
 )
 
 FIND_PATH(SPATH_INCLUDE_DIRS
     NAMES spath.h
-    HINTS ${WITH_SPATH_PREFIX}/include
+    HINTS ${WITH_SPATH_PREFIX}/include install/include
 )
 
 INCLUDE(FindPackageHandleStandardArgs)

--- a/src/filo.h
+++ b/src/filo.h
@@ -26,11 +26,14 @@ extern "C" {
 #define FILO_SUCCESS (0)
 #define FILO_FAILURE (1)
 
-/** intialize the library */
+/** initialize the library */
 int Filo_Init();
 
 /** shut down the library */
 int Filo_Finalize();
+
+/** Set a FILO config parameter */
+int Filo_Config(char *config_str);
 
 /** given a pointer to a filo file at filopath that was written by
  * filo_flush, copy files from their current location to path,
@@ -58,7 +61,8 @@ int Filo_Fetch(
   int* num_files,        /**< [OUT] - number of files copied */
   char*** src_filelist,  /**< [OUT] - full source path of each file copied */
   char*** dest_filelist, /**< [OUT] - full destination path of each file copied */
-  MPI_Comm comm          /**< [IN]  - communicator used for coordination and flow control */
+  MPI_Comm comm,         /**< [IN]  - communicator used for coordination and flow control */
+  const char *axl_xfer_str  /**< [IN]  - AXL transfer type ("sync", "pthread", "bbapi", etc) */
 );
 
 /** copies the list of source files to their corresponding
@@ -72,7 +76,8 @@ int Filo_Flush(
   int num_files,              /**< [IN] - number of files in source and dest lists */
   const char** src_filelist,  /**< [IN] - list of source paths */
   const char** dest_filelist, /**< [IN] - list of destination paths */
-  MPI_Comm comm               /**< [IN] - communicator used for coordination and flow control */
+  MPI_Comm comm,              /**< [IN] - communicator used for coordination and flow control */
+  const char *axl_xfer_str  /**< [IN] - AXL transfer type ("sync", "pthread", "bbapi", etc) */
 );
 
 int Filo_Flush_start(
@@ -81,7 +86,8 @@ int Filo_Flush_start(
   int num_files,              /**< [IN] - number of files in source and dest lists */
   const char** src_filelist,  /**< [IN] - list of source paths */
   const char** dest_filelist, /**< [IN] - list of destination paths */
-  MPI_Comm comm               /**< [IN] - communicator used for coordination and flow control */
+  MPI_Comm comm,              /**< [IN] - communicator used for coordination and flow control */
+  const char *axl_xfer_str    /**< [IN]  - AXL transfer type ("sync", "pthread", "bbapi", etc) */
 );
 
 int Filo_Flush_test(

--- a/test/test_filo.c
+++ b/test/test_filo.c
@@ -40,12 +40,12 @@ int main(int argc, char* argv[])
   sprintf(dest_filename, "./testfile_%d.out", rank);
 
   rc = Filo_Init();
-
   const char* filelist[1] = { filename };
   const char* dest_filelist[1] = { dest_filename };
 
   /* base path for storage is NULL, so destination files will be written to the local dir*/
-  rc = Filo_Flush("mapfile", NULL, 1, filelist, dest_filelist, MPI_COMM_WORLD);
+  rc = Filo_Flush("mapfile", NULL, 1, filelist, dest_filelist,
+    MPI_COMM_WORLD, "pthread");
 
   unlink(filename);
 
@@ -54,7 +54,8 @@ int main(int argc, char* argv[])
   char** src_filelist;
   char** dst_filelist;
   /* src base path is still NULL (consistent with Filo_Flush), but the dest base path is /dev/shm*/
-  rc = Filo_Fetch("mapfile", NULL, "/dev/shm", &num_files, &src_filelist, &dst_filelist, MPI_COMM_WORLD);
+  rc = Filo_Fetch("mapfile", NULL, "/dev/shm", &num_files, &src_filelist,
+    &dst_filelist, MPI_COMM_WORLD, "pthread");
 
   /* free file list returned by fetch */
   int i;

--- a/test/test_filo_async.c
+++ b/test/test_filo_async.c
@@ -45,7 +45,7 @@ int main(int argc, char* argv[])
   const char* dest_filelist[1] = { dest_filename };
 
   /* base path for storage is NULL, so destination files will be written to the local dir*/
-  rc = Filo_Flush_start("mapfile", NULL, 1, filelist, dest_filelist, MPI_COMM_WORLD);
+  rc = Filo_Flush_start("mapfile", NULL, 1, filelist, dest_filelist, MPI_COMM_WORLD, "pthread");
   rc = Filo_Flush_test("mapfile", MPI_COMM_WORLD);
   rc = Filo_Flush_wait("mapfile", MPI_COMM_WORLD);
 
@@ -56,7 +56,7 @@ int main(int argc, char* argv[])
   char** src_filelist;
   char** dst_filelist;
   /* src base path is still NULL (consistent with Filo_Flush), but the dest base path is /dev/shm*/
-  rc = Filo_Fetch("mapfile", NULL, "/dev/shm", &num_files, &src_filelist, &dst_filelist, MPI_COMM_WORLD);
+  rc = Filo_Fetch("mapfile", NULL, "/dev/shm", &num_files, &src_filelist, &dst_filelist, MPI_COMM_WORLD, NULL);
 
   /* free file list returned by fetch */
   int i;

--- a/test/test_filo_corrupt_fetch.c
+++ b/test/test_filo_corrupt_fetch.c
@@ -45,7 +45,7 @@ int main(int argc, char* argv[])
   const char* dest_filelist[1] = { dest_filename };
 
   /* base path for storage is NULL, so destination files will be written to the local dir*/
-  rc = Filo_Flush("mapfile", NULL, 1, filelist, dest_filelist, MPI_COMM_WORLD);
+  rc = Filo_Flush("mapfile", NULL, 1, filelist, dest_filelist, MPI_COMM_WORLD, NULL);
 
   //remove one of the flush destination files. This should result in Filo_Fetch returning error on ALL processes.
   if(rank == 1) unlink(dest_filename);
@@ -57,7 +57,7 @@ int main(int argc, char* argv[])
   char** src_filelist;
   char** dst_filelist;
   /* src base path is still NULL (consistent with Filo_Flush), but the dest base path is /dev/shm*/
-  int filo_ret = Filo_Fetch("mapfile", NULL, "/dev/shm", &num_files, &src_filelist, &dst_filelist, MPI_COMM_WORLD);
+  int filo_ret = Filo_Fetch("mapfile", NULL, "/dev/shm", &num_files, &src_filelist, &dst_filelist, MPI_COMM_WORLD, NULL);
   //check if the return value is error -- which is the correct behavior -- otherwise return fail
   if(filo_ret ==0){
     printf("Error: Filo_Fetch should fail because rank 1 destination file was removed pre- fetch. rank = %d, filo_ret = %d\n", rank, filo_ret);


### PR DESCRIPTION
- Add `bootstrap.sh` script to download and build dependencies

- Add `Filo_Config()` to the API.  This allows you to specify custom FILO config settings as key=value pairs.  Currently the only config supported is AXL_XFER_TYPE to specify the AXL transfer   type (default, native, sync, pthread, bbapi, etc..).

- Default to AXL_XFER_DEFAULT instead of AXL_XFER_SYNC

- Remove some trailing whitespace