### PR TITLE
add key value configuration interface to filo

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,7 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_BINARY_DIR})
 
 # Install header files
 LIST(APPEND libfilo_install_headers
-	filo.h
+	filo.h filo_internal.h
 )
 INSTALL(FILES ${libfilo_install_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 

--- a/src/filo.c
+++ b/src/filo.c
@@ -19,6 +19,7 @@
  * (C) Copyright 2015-2016 Intel Corporation.
  */
 
+#include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -49,6 +50,7 @@
 #include "axl.h"
 
 #include "filo.h"
+#include "filo_internal.h"
 
 #ifdef HAVE_LIBDTCMP
 #include "dtcmp.h"
@@ -67,6 +69,16 @@
 #define ARRAY_SIZE(a) (sizeof(a)/sizeof(a[0]))
 
 static kvtree* filo_outstanding = NULL;
+
+/* configurable options with their default values */
+int filo_fetch_width = 256;
+int filo_flush_width = 256;
+
+/* options we will pass to AXL */
+unsigned long filo_file_buf_size = 131072; /**< buffer size to use for file I/O operations */
+int filo_debug = 0;                        /**< if non-zero, print debug information*/
+int filo_make_directories = 1;             /**< whether Filo should first create parent directories before transferring files */
+int filo_copy_metadata = 0;                /**< whether file metadata should also be copied*/
 
 static int filo_alltrue(int valid, MPI_Comm comm)
 {
@@ -244,6 +256,169 @@ int Filo_Finalize(void)
   kvtree_delete(&filo_outstanding);
 
   return FILO_SUCCESS;
+}
+
+/** Set FILO config parameters */
+static kvtree* Filo_Config_Set(const kvtree* config)
+{
+  kvtree* retval = (kvtree*)config;
+
+  static const char* known_options[] = {
+    FILO_KEY_CONFIG_FETCH_WIDTH,
+    FILO_KEY_CONFIG_FLUSH_WIDTH,
+    FILO_KEY_CONFIG_FILE_BUF_SIZE,
+    FILO_KEY_CONFIG_DEBUG,
+    FILO_KEY_CONFIG_MKDIR,
+    FILO_KEY_CONFIG_COPY_METADATA,
+    NULL
+  };
+
+  kvtree* axl_config_values = kvtree_new();
+  assert(axl_config_values);
+
+  /* read out all options we know about */
+  /* TODO: this could be turned into a list of structs */
+  kvtree_util_get_int(config, FILO_KEY_CONFIG_FETCH_WIDTH,
+                      &filo_fetch_width);
+  kvtree_util_get_int(config, FILO_KEY_CONFIG_FLUSH_WIDTH,
+                      &filo_flush_width);
+
+  /* options we will pass to AXL */
+  /* TODO: replace the repeated code but just a list of equivalent option
+   * names?? */
+
+  kvtree_util_get_bytecount(config, FILO_KEY_CONFIG_FILE_BUF_SIZE,
+                            &filo_file_buf_size);
+
+  kvtree_util_get_int(config, FILO_KEY_CONFIG_DEBUG, &filo_debug);
+
+  kvtree_util_get_int(config, FILO_KEY_CONFIG_MKDIR, &filo_make_directories);
+
+  kvtree_util_get_int(config, FILO_KEY_CONFIG_COPY_METADATA,
+                      &filo_copy_metadata);
+
+  /* pass options on to AXL */
+  kvtree_util_set_bytecount(axl_config_values, AXL_KEY_CONFIG_FILE_BUF_SIZE,
+                            filo_file_buf_size);
+
+  kvtree_util_set_int(axl_config_values, AXL_KEY_CONFIG_DEBUG, filo_debug);
+
+  kvtree_util_set_int(axl_config_values, AXL_KEY_CONFIG_MKDIR,
+                      filo_make_directories);
+
+  kvtree_util_set_int(axl_config_values, AXL_KEY_CONFIG_COPY_METADATA,
+                      filo_copy_metadata);
+
+  if (AXL_Config(axl_config_values) == NULL) {
+    retval = NULL;
+  }
+
+  kvtree_delete(&axl_config_values);
+
+  /* report all unknown options (typos?) */
+  const kvtree_elem* elem;
+  for (elem = kvtree_elem_first(config); elem ;
+       elem = kvtree_elem_next(elem))
+  {
+    /* must be only one level deep, ie plain kev = value */
+    const kvtree* elem_hash = kvtree_elem_hash(elem);
+    assert(kvtree_size(elem_hash) == 1);
+    const kvtree* kvtree_first_elem_hash =
+      kvtree_elem_hash(kvtree_elem_first(elem_hash));
+    assert(kvtree_size(kvtree_first_elem_hash) == 0);
+    /* check against known options */
+    const char** opt;
+    int found = 0;
+    for (opt = known_options; *opt != NULL; opt++)
+    {
+      if (strcmp(*opt, kvtree_elem_key(elem)) == 0)
+      {
+        found = 1;
+        break;
+      }
+    }
+    if (!found) {
+      filo_err( "Unknown configuration parameter '%s' with value '%s' @ %s:%d",
+        kvtree_elem_key(elem),
+        kvtree_elem_key(kvtree_elem_first(kvtree_elem_hash(elem))),
+        __FILE__, __LINE__
+      );
+      retval = NULL;
+    }
+  }
+
+  return retval;
+}
+
+/** Get FILO config parameters */
+static kvtree* Filo_Config_Get(void)
+{
+  static const char* known_options[] = {
+    FILO_KEY_CONFIG_FETCH_WIDTH,
+    FILO_KEY_CONFIG_FLUSH_WIDTH,
+    FILO_KEY_CONFIG_FILE_BUF_SIZE,
+    FILO_KEY_CONFIG_DEBUG,
+    FILO_KEY_CONFIG_MKDIR,
+    FILO_KEY_CONFIG_COPY_METADATA,
+    NULL
+  };
+  int success = 1;
+
+  kvtree* retval = kvtree_new();
+  assert(retval != NULL);
+
+  if (kvtree_util_set_int(retval, FILO_KEY_CONFIG_FETCH_WIDTH, filo_fetch_width)
+    != KVTREE_SUCCESS)
+  {
+    success = 0;
+  }
+
+  if (kvtree_util_set_int(retval, FILO_KEY_CONFIG_FLUSH_WIDTH, filo_flush_width)
+    != KVTREE_SUCCESS)
+  {
+    success = 0;
+  }
+
+  if (kvtree_util_set_unsigned_long(retval, FILO_KEY_CONFIG_FILE_BUF_SIZE,
+    filo_file_buf_size) != KVTREE_SUCCESS)
+  {
+    success = 0;
+  }
+
+  if (kvtree_util_set_int(retval, FILO_KEY_CONFIG_DEBUG, filo_debug) !=
+    KVTREE_SUCCESS)
+  {
+    success = 0;
+  }
+
+  if (kvtree_util_set_int(retval, FILO_KEY_CONFIG_MKDIR, filo_make_directories)
+    != KVTREE_SUCCESS)
+  {
+    success = 0;
+  }
+
+  if (kvtree_util_set_int(retval, FILO_KEY_CONFIG_COPY_METADATA,
+    filo_copy_metadata) != KVTREE_SUCCESS)
+  {
+    success = 0;
+  }
+
+  if (!success) {
+    kvtree_delete(&retval);
+  }
+
+  return retval;
+}
+
+/** Get / Set FILO config parameters */
+kvtree* Filo_Config(const kvtree* config)
+{
+  if (config != NULL) {
+    return Filo_Config_Set(config);
+  } else {
+    return Filo_Config_Get();
+  }
+  return NULL; /* NOTREACHED */
 }
 
 /*
@@ -607,8 +782,6 @@ static int filo_axl_stop(MPI_Comm comm)
   return rc;
 }
 
-static int filo_window_width = 256;
-
 /*
  * Fetch files specified in file_list into specified dir and update
  * filemap.
@@ -622,7 +795,8 @@ static int filo_axl_sliding_window(
   const char** src_filelist,
   const char** dest_filelist,
   MPI_Comm comm,
-  const char *axl_xfer_str)
+  const char *axl_xfer_str,
+  const int window_width)
 {
   int success = FILO_SUCCESS;
 
@@ -643,7 +817,7 @@ static int filo_axl_sliding_window(
     }
 
     /* now, have a sliding window of w processes read simultaneously */
-    int w = filo_window_width;
+    int w = window_width;
     if (w > ranks_world-1) {
       w = ranks_world-1;
     }
@@ -802,7 +976,7 @@ int Filo_Fetch(
   int success = 1;
   if (path != NULL) {
     if (filo_axl_sliding_window(count, src_filelist, dest_filelist, comm,
-          axl_xfer_str) != FILO_SUCCESS) {
+          axl_xfer_str, filo_fetch_width) != FILO_SUCCESS) {
       success = 0;
     }
   } else {
@@ -1000,7 +1174,7 @@ int Filo_Flush(
 
     /* write files (via AXL) */
     if (filo_axl_sliding_window(num_files, src_filelist, dest_filelist, comm,
-      axl_xfer_str) != FILO_SUCCESS) {
+      axl_xfer_str, filo_flush_width) != FILO_SUCCESS) {
       success = 0;
     }
   } else {

--- a/src/filo.c
+++ b/src/filo.c
@@ -207,7 +207,7 @@ int filo_mkdir(const char* basepath, const char* dir, mode_t mode)
   return rc;
 }
 
-int Filo_Init()
+int Filo_Init(void)
 {
   if (AXL_Init() != AXL_SUCCESS) {
     return FILO_FAILURE;
@@ -227,7 +227,7 @@ int Filo_Init()
   return FILO_SUCCESS;
 }
 
-int Filo_Finalize()
+int Filo_Finalize(void)
 {
   if (AXL_Finalize() != AXL_SUCCESS) {
     return FILO_FAILURE;

--- a/src/filo.h
+++ b/src/filo.h
@@ -26,14 +26,56 @@ extern "C" {
 #define FILO_SUCCESS (0)
 #define FILO_FAILURE (1)
 
+#define FILO_KEY_CONFIG_FETCH_WIDTH "FETCH_WIDTH"
+#define FILO_KEY_CONFIG_FLUSH_WIDTH "FLUSH_WIDTH"
+/* option below are not used by FILO directly but passed on to AXL */
+/* TODO: need to define defaults in FILO as discussed with Adam */
+#define FILO_KEY_CONFIG_FILE_BUF_SIZE "FILE_BUF_SIZE"
+#define FILO_KEY_CONFIG_DEBUG "DEBUG"
+#define FILO_KEY_CONFIG_MKDIR "MKDIR"
+#define FILO_KEY_CONFIG_COPY_METADATA "COPY_METADATA"
+
 /** initialize the library */
 int Filo_Init(void);
 
 /** shut down the library */
 int Filo_Finalize(void);
 
-/** Set a FILO config parameter */
-int Filo_Config(char *config_str);
+extern int filo_fetch_width; /**< number of processes to read files simultaneously */
+extern int filo_flush_width; /**< number of processes to write files simultaneously*/
+extern unsigned long filo_file_buf_size; /**< buffer size to use for file I/O operations */
+extern int filo_debug; /**< if non-zero, print debug information*/
+extern int filo_make_directories; /**< whether Filo should first create parent directories before transferring files */
+extern int filo_copy_metadata; /**< whether file metadata should also be copied*/
+
+/* needs to be above doxygen comment to get association right */
+typedef struct kvtree_struct kvtree;
+
+/**
+ * Get/set Filo configuration values.
+ *
+ * The following configuration options can be set (type in parenthesis):
+ *   * "FETCH_WIDTH" (int) - number of processes to read files simultaneously.
+ *   * "FLUSH_WIDTH" (int) - number of processes to write files simultaneously.
+ *   * "FILE_BUF_SIZE" (byte count [IN], unsigned long int [OUT]) - buffer size
+ *     to chunk file transfer. Must not exceed ULONG_MAX.
+ *   * "DEBUG" (int) - if non-zero, output debug information from inside
+ *     Filo.
+ *   * "MKDIR" (int) - whether Filo should first create parent directories
+ *     before transferring files.
+ *   * "COPY_METADATA" (int) - whether file metadata should also be copied.
+ *   .
+ * Symbolic names FILO_KEY_CONFIG_FOO are defined in filo.h and should be used
+ * instead of the strings whenever possible to guard against typos in strings.
+ *
+ * \result If config != NULL, then return config on success.  If config == NULL
+ *         (you're querying the config) then return a new kvtree on success,
+ *         which must be kvtree_delete()ed by the caller. NULL on any failures.
+ * \param config The new configuration. If config == NULL, then return a new
+ *               kvtree with all the configuration values.
+ *
+ */
+kvtree* Filo_Config(const kvtree* config);
 
 /** given a pointer to a filo file at filopath that was written by
  * filo_flush, copy files from their current location to path,

--- a/src/filo.h
+++ b/src/filo.h
@@ -27,10 +27,10 @@ extern "C" {
 #define FILO_FAILURE (1)
 
 /** initialize the library */
-int Filo_Init();
+int Filo_Init(void);
 
 /** shut down the library */
-int Filo_Finalize();
+int Filo_Finalize(void);
 
 /** Set a FILO config parameter */
 int Filo_Config(char *config_str);

--- a/src/filo_internal.h
+++ b/src/filo_internal.h
@@ -1,0 +1,28 @@
+#ifndef FILO_INTERNAL_H
+#define FILO_INTERNAL_H
+
+/** \defgroup filo FILO
+ *  \brief Internal variables for FILO */
+
+/** \file filo_internal.h
+ *  \ingroup filo
+ *  \brief Internal variables for FILO */
+
+/* enable C++ codes to include this header directly */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern int filo_fetch_width; /**< number of processes to read files simultaneously */
+extern int filo_flush_width; /**< number of processes to write files simultaneously*/
+extern unsigned long filo_file_buf_size; /**< buffer size to use for file I/O operations */
+extern int filo_debug; /**< if non-zero, print debug information*/
+extern int filo_make_directories; /**< whether Filo should first create parent directories before transferring files */
+extern int filo_copy_metadata; /**< whether file metadata should also be copied*/
+
+/* enable C++ codes to include this header directly */
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* FILO_INTERNAL_H */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,6 +21,10 @@ TARGET_LINK_LIBRARIES(filo_async_test ${SPATH_EXTERNAL_LIBS} filo)
 FILO_ADD_TEST(filo_async_test 256 "")
 #ADD_TEST(NAME filo_async_test COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 3 ./filo_async_test)
 
+ADD_EXECUTABLE(test_config test_filo_async.c)
+TARGET_LINK_LIBRARIES(test_config ${SPATH_EXTERNAL_LIBS} filo)
+ADD_TEST(NAME test_config COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 1 ./test_config)
+
 ####################
 # make a verbose "test" target named "check"
 ####################

--- a/test/test_config.c
+++ b/test/test_config.c
@@ -1,0 +1,328 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "filo.h"
+#include "filo_internal.h"
+
+#include "kvtree.h"
+#include "kvtree_util.h"
+
+/* helper function to check for known options */
+void check_known_options(const kvtree* configured_values,
+                         const char* known_options[])
+{
+  /* report all unknown options (typos?) */
+  const kvtree_elem* elem;
+  for (elem = kvtree_elem_first(configured_values);
+       elem != NULL;
+       elem = kvtree_elem_next(elem))
+  {
+    const char* key = kvtree_elem_key(elem);
+
+    /* must be only one level deep, ie plain kev = value */
+    const kvtree* elem_hash = kvtree_elem_hash(elem);
+    if (kvtree_size(elem_hash) != 1) {
+      printf("Element %s has unexpected number of values: %d", key,
+           kvtree_size(elem_hash));
+      exit(EXIT_FAILURE);
+    }
+
+    const kvtree* kvtree_first_elem_hash =
+      kvtree_elem_hash(kvtree_elem_first(elem_hash));
+    if (kvtree_size(kvtree_first_elem_hash) != 0) {
+      printf("Element %s is not a pure value", key);
+      exit(EXIT_FAILURE);
+    }
+
+    /* check against known options */
+    const char** opt;
+    int found = 0;
+    for (opt = known_options; *opt != NULL; opt++) {
+      if (strcmp(*opt, key) == 0) {
+        found = 1;
+        break;
+      }
+    }
+    if (! found) {
+      printf("Unknown configuration parameter '%s' with value '%s'\n",
+        kvtree_elem_key(elem),
+        kvtree_elem_key(kvtree_elem_first(kvtree_elem_hash(elem)))
+      );
+      exit(EXIT_FAILURE);
+    }
+  }
+}
+
+/* helper function to check option values in kvtree against expected values */
+    FILO_KEY_CONFIG_FETCH_WIDTH,
+    FILO_KEY_CONFIG_FLUSH_WIDTH,
+    FILO_KEY_CONFIG_FILE_BUF_SIZE,
+    FILO_KEY_CONFIG_DEBUG,
+    FILO_KEY_CONFIG_MKDIR,
+    FILO_KEY_CONFIG_COPY_METADATA,
+void check_options(const int exp_fetch_width, const int exp_flush_width,
+  const unsigned long exp_file_buf_width, const int exp_debug,
+  const int exp_make_directories, const int exp_copy_metadata)
+{
+  kvtree* config = Filo_Config(NULL);
+  if (config == NULL) {
+    printf("Filo_Config failed\n");
+    exit(EXIT_FAILURE);
+  }
+
+  int cfg_fetch_width;
+  if (kvtree_util_get_int(config, FILO_KEY_CONFIG_FETCH_WIDTH, &cfg_fetch_width) !=
+    KVTREE_SUCCESS)
+  {
+    printf("Could not get %s from Filo_Config\n",
+           FILO_KEY_CONFIG_FETCH_WIDTH);
+    exit(EXIT_FAILURE);
+  }
+  if (cfg_fetch_width != exp_fetch_width) {
+    printf("Filo_Config returned unexpected value %d for %s. Expected %d.\n",
+           cfg_fetch_width, FILO_KEY_CONFIG_FETCH_WIDTH,
+           exp_fetch_width);
+    exit(EXIT_FAILURE);
+  }
+
+  int cfg_flush_width;
+  if (kvtree_util_get_int(config, FILO_KEY_CONFIG_FLUSH_WIDTH, &cfg_flush_width) !=
+    KVTREE_SUCCESS)
+  {
+    printf("Could not get %s from Filo_Config\n",
+           FILO_KEY_CONFIG_FLUSH_WIDTH);
+    exit(EXIT_FAILURE);
+  }
+  if (cfg_flush_width != exp_flush_width) {
+    printf("Filo_Config returned unexpected value %d for %s. Expected %d.\n",
+           cfg_flush_width, FILO_KEY_CONFIG_FLUSH_WIDTH,
+           exp_flush_width);
+    exit(EXIT_FAILURE);
+  }
+
+  unsigned int cfg_file_buf_size;
+  if (kvtree_util_get_unsigned_int(config, FILO_KEY_CONFIG_FILE_BUF_SIZE,
+    &cfg_file_buf_size) != KVTREE_SUCCESS)
+  {
+    printf("Could not get %s from Filo_Config\n",
+           FILO_KEY_CONFIG_FILE_BUF_SIZE);
+    exit(EXIT_FAILURE);
+  }
+  if (cfg_file_buf_size != exp_file_buf_size) {
+    printf("Filo_Config returned unexpected value %d for %s. Expected %d.\n",
+           cfg_file_buf_size, FILO_KEY_CONFIG_FILE_BUF_SIZE,
+           exp_file_buf_size);
+    exit(EXIT_FAILURE);
+  }
+
+  int cfg_debug;
+  if (kvtree_util_get_int(config, FILO_KEY_CONFIG_DEBUG, &cfg_debug) !=
+    KVTREE_SUCCESS)
+  {
+    printf("Could not get %s from Filo_Config\n",
+           FILO_KEY_CONFIG_DEBUG);
+    exit(EXIT_FAILURE);
+  }
+  if (cfg_debug != exp_debug) {
+    printf("Filo_Config returned unexpected value %d for %s. Expected %d.\n",
+           cfg_debug, FILO_KEY_CONFIG_DEBUG,
+           exp_debug);
+    exit(EXIT_FAILURE);
+  }
+
+  int cfg_make_directories;
+  if (kvtree_util_get_int(config, FILO_KEY_CONFIG_DEBUG, &cfg_make_directories) !=
+    KVTREE_SUCCESS)
+  {
+    printf("Could not get %s from Filo_Config\n",
+           FILO_KEY_CONFIG_DEBUG);
+    exit(EXIT_FAILURE);
+  }
+  if (cfg_make_directories != exp_make_directories) {
+    printf("Filo_Config returned unexpected value %d for %s. Expected %d.\n",
+           cfg_make_directories, FILO_KEY_CONFIG_DEBUG,
+           exp_make_directories);
+    exit(EXIT_FAILURE);
+  }
+
+  int cfg_copy_metadata;
+  if (kvtree_util_get_int(config, FILO_KEY_CONFIG_COPY_METADATA, &cfg_copy_metadata) !=
+    KVTREE_SUCCESS)
+  {
+    printf("Could not get %s from Filo_Config\n",
+           FILO_KEY_CONFIG_COPY_METADATA);
+    exit(EXIT_FAILURE);
+  }
+  if (cfg_copy_metadata != exp_copy_metadata) {
+    printf("Filo_Config returned unexpected value %d for %s. Expected %d.\n",
+           cfg_copy_metadata, FILO_KEY_CONFIG_COPY_METADATA,
+           exp_copy_metadata);
+    exit(EXIT_FAILURE);
+  }
+
+  static const char* known_options[] = {
+    FILO_KEY_CONFIG_FETCH_WIDTH,
+    FILO_KEY_CONFIG_FLUSH_WIDTH,
+    FILO_KEY_CONFIG_FILE_BUF_SIZE,
+    FILO_KEY_CONFIG_DEBUG,
+    FILO_KEY_CONFIG_MKDIR,
+    FILO_KEY_CONFIG_COPY_METADATA,
+    NULL
+  };
+  check_known_options(config, known_options);
+
+  kvtree_delete(&config);
+}
+
+int main(int argc, char *argv[])
+{
+  int rc;
+  char *conf_file = NULL;
+  kvtree* filo_config_values = kvtree_new();
+
+  MPI_Init(&argc, &argv);
+
+  rc = Filo_Init(conf_file);
+  if (rc != Filo_SUCCESS) {
+    printf("Filo_Init() failed (error %d)\n", rc);
+    return rc;
+  }
+
+  int old_filo_fetch_width = filo_fetch_width;
+  int old_filo_flush_width = filo_flush_width;
+  unsigned long old_filo_file_buf_size = filo_file_buf_size;
+  int old_filo_debug = filo_debug;
+  int old_filo_make_directories = filo_make_directories;
+  int old_filo_copy_metadata = filo_copy_metadata;
+
+  int new_filo_fetch_width = old_filo_fetch_width + 1;
+  int new_filo_flush_width = old_filo_flush_width + 1;
+  unsigned long new_filo_file_buf_size = old_filo_file_buf_size + 1;
+  int new_filo_debug = !old_filo_debug;
+  int new_filo_make_directories = !old_filo_make_directories;
+  int new_filo_copy_metadata = !old_filo_copy_metadata;
+
+  check_options(old_fetch_width, old_flush_width, old_file_buf_width,
+                old_debug, old_make_directories, old_copy_metadata);
+
+  /* check Filo configuration settings */
+  rc = kvtree_util_set_int(filo_config_values, FILO_KEY_CONFIG_FETCH_WIDTH,
+                           !old_filo_fetch_width);
+  if (rc != KVTREE_SUCCESS) {
+    printf("kvtree_util_set_int failed (error %d)\n", rc);
+    return rc;
+  }
+
+  printf("Configuring Filo (first set of options)...\n");
+  if (Filo_Config(filo_config_values) == NULL) {
+    printf("Filo_Config() failed\n");
+    return EXIT_FAILURE;
+  }
+
+  /* check that option was set */
+
+  if (filo_fetch_width != !old_filo_fetch_width) {
+    printf("Filo_Config() failed to set %s: %d != %d\n",
+           FILO_KEY_CONFIG_FETCH_WIDTH, filo_fetch_width, new_filo_fetch_width);
+    return EXIT_FAILURE;
+  }
+
+  check_options(new_fetch_width, old_flush_width, old_file_buf_width,
+                old_debug, old_make_directories, old_copy_metadata);
+
+  /* set remainder of options */
+  kvtree_delete(&filo_config_values);
+  filo_config_values = kvtree_new();
+
+  rc = kvtree_util_set_int(filo_config_values, FILO_KEY_CONFIG_FLUSH_WIDTH,
+                           new_filo_flush_width);
+  if (rc != KVTREE_SUCCESS) {
+    printf("kvtree_util_set_int failed (error %d)\n", rc);
+    return rc;
+  }
+  rc = kvtree_util_set_unsigned_int(filo_config_values,
+    FILO_KEY_CONFIG_FILE_BUF_SIZE, new_filo_file_buf_size);
+  if (rc != KVTREE_SUCCESS) {
+    printf("kvtree_util_set_unsigned_int failed (error %d)\n", rc);
+    return rc;
+  }
+  rc = kvtree_util_set_int(filo_config_values, FILO_KEY_CONFIG_DEBUG,
+                           new_filo_debug);
+  if (rc != KVTREE_SUCCESS) {
+    printf("kvtree_util_set_int failed (error %d)\n", rc);
+    return rc;
+  }
+  rc = kvtree_util_set_int(filo_config_values, FILO_KEY_CONFIG_MKDIR,
+                           new_filo_make_directories);
+  if (rc != KVTREE_SUCCESS) {
+    printf("kvtree_util_set_int failed (error %d)\n", rc);
+    return rc;
+  }
+  rc = kvtree_util_set_int(filo_config_values, FILO_KEY_CONFIG_COPY_METADATA,
+                           new_filo_copy_metadata);
+  if (rc != KVTREE_SUCCESS) {
+    printf("kvtree_util_set_int failed (error %d)\n", rc);
+    return rc;
+  }
+
+  printf("Configuring Filo (second set of options)...\n");
+  if (Filo_Config(filo_config_values) == NULL) {
+    printf("Filo_Config() failed\n");
+    return EXIT_FAILURE;
+  }
+
+  /* check all options once more */
+
+  if (filo_fetch_width != !old_filo_fetch_width) {
+    printf("Filo_Config() failed to set %s: %d != %d\n",
+           FILO_KEY_CONFIG_FETCH_WIDTH, filo_fetch_width,
+           new_filo_fetch_width);
+    return EXIT_FAILURE;
+  }
+
+  if (filo_flush_width != !old_filo_flush_width) {
+    printf("Filo_Config() failed to set %s: %d != %d\n",
+           FILO_KEY_CONFIG_FLUSH_WIDTH, filo_flush_width,
+           new_filo_flush_width);
+    return EXIT_FAILURE;
+  }
+
+  if (filo_file_buf_size != !old_filo_file_buf_size) {
+    printf("Filo_Config() failed to set %s: %ul != %ul\n",
+           FILO_KEY_CONFIG_FILE_BUF_SIZE, filo_file_buf_size,
+           new_filo_file_buf_size);
+    return EXIT_FAILURE;
+  }
+
+  if (filo_debug != !old_filo_debug) {
+    printf("Filo_Config() failed to set %s: %d != %d\n",
+           FILO_KEY_CONFIG_DEBUG, filo_debug, new_filo_debug);
+    return EXIT_FAILURE;
+  }
+
+  if (filo_make_directories != !old_filo_make_directories) {
+    printf("Filo_Config() failed to set %s: %d != %d\n",
+           FILO_KEY_CONFIG_MKDIR, filo_make_directories,
+           new_filo_make_directories);
+    return EXIT_FAILURE;
+  }
+
+  if (filo_copy_metadata != !old_filo_copy_metadata) {
+    printf("Filo_Config() failed to set %s: %d != %d\n",
+           FILO_KEY_CONFIG_COPY_METADATA, filo_copy_metadata,
+           new_filo_copy_metadata);
+    return EXIT_FAILURE;
+  }
+
+  check_options(new_fetch_width, new_flush_width, new_file_buf_width,
+                new_debug, new_make_directories, new_copy_metadata);
+
+  rc = Filo_Finalize();
+  if (rc != Filo_SUCCESS) {
+    printf("Filo_Finalize() failed (error %d)\n", rc);
+    return rc;
+  }
+
+  MPI_Finalize();
+
+  return Filo_SUCCESS;
+}


### PR DESCRIPTION
This pull request adds a configuration interface to filo, similar in functionality to the one in AXL. Specifically it adds a new function `Filo_Config`:

```
/**
 * Get/set Filo configuration values.
 *
 * The following configuration options can be set (type in parenthesis):
 *   * "FETCH_WIDTH" (int) - number of processes to read files simultaneously.
 *   * "FLUSH_WIDTH" (int) - number of processes to write files simultaneously.
 *   * "FILE_BUF_SIZE" (byte count [IN], unsigned long int [OUT]) - buffer size
 *     to chunk file transfer. Must not exceed ULONG_MAX.
 *   * "DEBUG" (int) - if non-zero, output debug information from inside
 *     Filo.
 *   * "MKDIR" (int) - whether Filo should first create parent directories
 *     before transferring files.
 *   * "COPY_METADATA" (int) - whether file metadata should also be copied.
 *   .
 * Symbolic names FILO_KEY_CONFIG_FOO are defined in filo.h and should be used
 * instead of the strings whenever possible to guard against typos in strings.
 *
 * \result If config != NULL, then return config on success.  If config=NULL
 *         (you're querying the config) then return a new kvtree on success.
 *         NULL on any failures.
 * \param config The new configuration. If config=NULL, then return a kvtree
 *                with all the configuration values.
 *
 */
kvtree* Filo_Config(const kvtree* config);
```

as well as a new test `test_config` to check functionality of this interface.

In `Filo_Config` all configuration options that affect AXL are passed down to AXL, even when not set by the user, ie Filo's defaults for these options will override AXL's if `Filo_Config` is called (but not otherwise).

Querying options will return Filo's the current value of the options. If an option was passed down to AXL then the value returned is Filo's copy ie it does not query AXL.

Options can be configured multiple times at runtime and it is the user's responsibility ensure that this does not lead to problems.